### PR TITLE
fix: disable Bonjour on loopback-only Android hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Auto-disable Bonjour/mDNS when Android/Termux only exposes loopback (`lo`) to Node.js, preventing noisy Gateway shutdown warnings like `_openclaw-gw._tcp.local.` goodbye timeouts.
+
 ## [1.0.6] - 2026-03-10
 
 ### Changed

--- a/README.ko.md
+++ b/README.ko.md
@@ -319,7 +319,7 @@ openclaw-android/
 ├── update-core.sh              # 기존 설치 환경 경량 업데이터
 ├── uninstall.sh                # 깔끔한 제거 (오케스트레이터)
 ├── patches/
-│   ├── glibc-compat.js        # Node.js 런타임 패치 (os.cpus, networkInterfaces)
+│   ├── glibc-compat.js        # Node.js 런타임 패치 (os.cpus, networkInterfaces, Bonjour loopback guard)
 │   ├── argon2-stub.js          # argon2 네이티브 모듈용 JS 스텅 (code-server)
 │   ├── termux-compat.h         # Bionic 네이티브 빌드용 C 헤더 (sharp)
 │   ├── spawn.h                 # POSIX spawn 스텅 헤더

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ openclaw-android/
 ├── update-core.sh              # Lightweight updater for existing installations
 ├── uninstall.sh                # Clean removal (orchestrator)
 ├── patches/
-│   ├── glibc-compat.js        # Node.js runtime patches (os.cpus, networkInterfaces)
+│   ├── glibc-compat.js        # Node.js runtime patches (os.cpus, networkInterfaces, Bonjour loopback guard)
 │   ├── argon2-stub.js          # JS stub for argon2 native module (code-server)
 │   ├── termux-compat.h         # C header for Bionic native builds (sharp)
 │   ├── spawn.h                 # POSIX spawn stub header

--- a/android/app/src/main/assets/glibc-compat.js
+++ b/android/app/src/main/assets/glibc-compat.js
@@ -11,6 +11,7 @@
  * What's still needed (kernel/Android-level restrictions, not libc):
  * - os.cpus() fallback: SELinux blocks /proc/stat on Android 8+
  * - os.networkInterfaces() safety: EACCES on some Android configurations
+ * - Bonjour auto-disable on loopback-only hosts: some Android/Termux setups only expose `lo`
  * - /bin/sh path shim: Android 7-8 lacks /bin/sh (Android 9+ has it)
  *
  * Loaded via node wrapper script: node --require <path>/glibc-compat.js
@@ -63,27 +64,55 @@ os.cpus = function cpus() {
 // ─── os.networkInterfaces() safety ──────────────────────────
 // Some Android configurations throw EACCES when reading network
 // interface information. Wrap with try-catch to prevent crashes.
+//
+// Additionally, some Android/Termux setups only expose the loopback
+// interface (`lo`) to Node.js. In that situation, OpenClaw's Bonjour
+// advertiser can't provide real LAN discovery and may log noisy
+// goodbye timeouts on shutdown. Auto-disable Bonjour when only
+// loopback interfaces are visible.
 
 const _originalNetworkInterfaces = os.networkInterfaces;
 
-os.networkInterfaces = function networkInterfaces() {
+function createLoopbackInterfaces() {
+  return {
+    lo: [
+      {
+        address: '127.0.0.1',
+        netmask: '255.0.0.0',
+        family: 'IPv4',
+        mac: '00:00:00:00:00:00',
+        internal: true,
+        cidr: '127.0.0.1/8',
+      },
+    ],
+  };
+}
+
+function hasNonLoopbackInterface(interfaces) {
   try {
-    return _originalNetworkInterfaces.call(os);
+    return Object.values(interfaces).some(entries =>
+      Array.isArray(entries) && entries.some(entry => entry && entry.internal === false)
+    );
   } catch {
-    // Return minimal loopback interface
-    return {
-      lo: [
-        {
-          address: '127.0.0.1',
-          netmask: '255.0.0.0',
-          family: 'IPv4',
-          mac: '00:00:00:00:00:00',
-          internal: true,
-          cidr: '127.0.0.1/8',
-        },
-      ],
-    };
+    return false;
   }
+}
+
+function maybeDisableBonjour(interfaces) {
+  if (process.env.OPENCLAW_DISABLE_BONJOUR) return;
+  if (hasNonLoopbackInterface(interfaces)) return;
+  process.env.OPENCLAW_DISABLE_BONJOUR = '1';
+}
+
+os.networkInterfaces = function networkInterfaces() {
+  let interfaces;
+  try {
+    interfaces = _originalNetworkInterfaces.call(os);
+  } catch {
+    interfaces = createLoopbackInterfaces();
+  }
+  maybeDisableBonjour(interfaces);
+  return interfaces;
 };
 
 // ─── /bin/sh path shim (Android 7-8 only) ───────────────────

--- a/patches/glibc-compat.js
+++ b/patches/glibc-compat.js
@@ -11,6 +11,7 @@
  * What's still needed (kernel/Android-level restrictions, not libc):
  * - os.cpus() fallback: SELinux blocks /proc/stat on Android 8+
  * - os.networkInterfaces() safety: EACCES on some Android configurations
+ * - Bonjour auto-disable on loopback-only hosts: some Android/Termux setups only expose `lo`
  * - /bin/sh path shim: Android 7-8 lacks /bin/sh (Android 9+ has it)
  *
  * Loaded via node wrapper script: node --require <path>/glibc-compat.js
@@ -63,27 +64,55 @@ os.cpus = function cpus() {
 // ─── os.networkInterfaces() safety ──────────────────────────
 // Some Android configurations throw EACCES when reading network
 // interface information. Wrap with try-catch to prevent crashes.
+//
+// Additionally, some Android/Termux setups only expose the loopback
+// interface (`lo`) to Node.js. In that situation, OpenClaw's Bonjour
+// advertiser can't provide real LAN discovery and may log noisy
+// goodbye timeouts on shutdown. Auto-disable Bonjour when only
+// loopback interfaces are visible.
 
 const _originalNetworkInterfaces = os.networkInterfaces;
 
-os.networkInterfaces = function networkInterfaces() {
+function createLoopbackInterfaces() {
+  return {
+    lo: [
+      {
+        address: '127.0.0.1',
+        netmask: '255.0.0.0',
+        family: 'IPv4',
+        mac: '00:00:00:00:00:00',
+        internal: true,
+        cidr: '127.0.0.1/8',
+      },
+    ],
+  };
+}
+
+function hasNonLoopbackInterface(interfaces) {
   try {
-    return _originalNetworkInterfaces.call(os);
+    return Object.values(interfaces).some(entries =>
+      Array.isArray(entries) && entries.some(entry => entry && entry.internal === false)
+    );
   } catch {
-    // Return minimal loopback interface
-    return {
-      lo: [
-        {
-          address: '127.0.0.1',
-          netmask: '255.0.0.0',
-          family: 'IPv4',
-          mac: '00:00:00:00:00:00',
-          internal: true,
-          cidr: '127.0.0.1/8',
-        },
-      ],
-    };
+    return false;
   }
+}
+
+function maybeDisableBonjour(interfaces) {
+  if (process.env.OPENCLAW_DISABLE_BONJOUR) return;
+  if (hasNonLoopbackInterface(interfaces)) return;
+  process.env.OPENCLAW_DISABLE_BONJOUR = '1';
+}
+
+os.networkInterfaces = function networkInterfaces() {
+  let interfaces;
+  try {
+    interfaces = _originalNetworkInterfaces.call(os);
+  } catch {
+    interfaces = createLoopbackInterfaces();
+  }
+  maybeDisableBonjour(interfaces);
+  return interfaces;
 };
 
 // ─── /bin/sh path shim (Android 7-8 only) ───────────────────


### PR DESCRIPTION
## Summary

This fixes a Termux/Android-specific Bonjour issue where Node.js only exposes the loopback interface (`lo`) to `os.networkInterfaces()`.

In that environment, OpenClaw's Gateway Bonjour advertiser can't provide real LAN discovery, but it still tries to advertise and send goodbye packets on shutdown. That leads to noisy warnings like:

```text
[_openclaw-gw._tcp.local.] Failed to send goodbye requests:
- Sending packet on interface lo timed out!
... Goodbye failed as of socket errors!
```

## What changed

- keep the existing `os.networkInterfaces()` crash-safe wrapper
- automatically set `OPENCLAW_DISABLE_BONJOUR=1` when the visible interface set is loopback-only
- keep the same behavior when non-loopback interfaces are available
- sync the same change into the bundled APK asset copy of `glibc-compat.js`
- note the fix in `CHANGELOG.md`

## Why here

I intentionally did **not** patch OpenClaw's hashed dist files from this repo.

`openclaw-android` already ships Android-specific runtime shims via `glibc-compat.js`, and this bug is caused by an Android/Termux networking visibility quirk rather than a general OpenClaw logic bug. Handling it in the compat layer keeps the fix stable across upstream OpenClaw releases.

## Validation

Tested locally on Android Termux where `os.networkInterfaces()` currently returns only `lo`.

```js
require('./patches/glibc-compat.js')
const os = require('os')
console.log(os.networkInterfaces())
console.log(process.env.OPENCLAW_DISABLE_BONJOUR)
```

Result:
- interfaces: `lo` only
- `OPENCLAW_DISABLE_BONJOUR=1`

That matches the intended behavior and prevents the shutdown-time Bonjour goodbye warnings in loopback-only environments.
