### PR TITLE
Document OpenClaw plugin setup

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -161,6 +161,18 @@ openclaw gateway
 
 > 게이트웨이를 중지하려면 `Ctrl+C`를 누르세요. `Ctrl+Z`는 프로세스를 종료하지 않고 일시 중지만 시키므로, 반드시 `Ctrl+C`를 사용하세요.
 
+## OpenClaw 플러그인 설치
+
+`openclaw gateway`가 실행 중이면 두 번째 Termux 탭을 열어 선택적 OpenClaw 플러그인을 설치할 수 있습니다. 예를 들어 [TweetClaw](https://github.com/Xquik-dev/tweetclaw)는 search tweets, search tweet replies, follower export, user lookup, media upload and download, direct messages, monitors, webhooks, giveaway draws, 검토된 post 또는 reply 워크플로를 위한 X/Twitter 자동화를 추가합니다.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
+```bash
+openclaw plugins install clawhub:@xquik/tweetclaw
+```
+
+TweetClaw는 자격 증명 정보 없이도 설치할 수 있습니다. 설치 후 OpenClaw 플러그인 설정을 통해 Xquik 액세스를 추가하세요. 게이트웨이 탭을 계속 실행한 상태에서 별도 탭으로 플러그인을 설정하세요.
+
 ## 프로세스 라이브 상태 유지
 
 Android는 백그라운드 프로세스를 종료하거나 화면이 꺼지면 스로틀링할 수 있습니다. [프로세스 라이브 상태 유지 가이드](docs/disable-phantom-process-killer.ko.md)에서 모든 권장 설정(개발자 옵션, 화면 켜짐 유지, 충전 제한, 배터리 최적화, Phantom Process Killer)을 확인하세요.
@@ -287,7 +299,7 @@ OpenClaw은 [node-llama-cpp](https://github.com/withcatai/node-llama-cpp)를 통
 | 컴포넌트 | 역할 | 설치 방식 |
 |----------|------|-----------|
 | [OpenClaw](https://github.com/openclaw/openclaw) | AI 에이전트 플랫폼 (핵심) | `npm install -g` |
-| [clawdhub](https://github.com/AidanPark/clawdhub) | OpenClaw 스킬 매니저 | `npm install -g` |
+| [ClawHub](https://github.com/openclaw/clawhub) | OpenClaw 스킬 및 플러그인 레지스트리 | `npm install -g` |
 | [PyYAML](https://pyyaml.org/) | `.skill` 패키징용 YAML 파서 | `pip install` |
 | libvips | sharp 빌드용 이미지 처리 헤더 | `pkg install` (업데이트 시) |
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ openclaw gateway
 
 > To stop the gateway, press `Ctrl+C`. Do not use `Ctrl+Z` — it only suspends the process without terminating it.
 
+## Install OpenClaw Plugins
+
+After `openclaw gateway` is running, open a second Termux tab to install optional OpenClaw plugins. For example, [TweetClaw](https://github.com/Xquik-dev/tweetclaw) adds X/Twitter automation for search tweets, search tweet replies, follower export, user lookup, media upload and download, direct messages, monitors, webhooks, giveaway draws, and reviewed post or reply workflows.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
+```bash
+openclaw plugins install clawhub:@xquik/tweetclaw
+```
+
+TweetClaw installs before credentials are configured. Add Xquik access through OpenClaw plugin config after installation. Leave the gateway tab running while using a separate tab for plugin setup.
+
 ## Keeping Processes Alive
 
 Android may kill background processes or throttle them when the screen is off. See the [Keeping Processes Alive guide](docs/disable-phantom-process-killer.md) for all recommended settings (Developer Options, Stay Awake, charge limit, battery optimization, and Phantom Process Killer).
@@ -289,7 +301,7 @@ These are controlled by the platform's `config.env` flags. For OpenClaw, all are
 | Component | Role | Install Method |
 |-----------|------|----------------|
 | [OpenClaw](https://github.com/openclaw/openclaw) | AI agent platform (core) | `npm install -g` |
-| [clawdhub](https://github.com/AidanPark/clawdhub) | Skill manager for OpenClaw | `npm install -g` |
+| [ClawHub](https://github.com/openclaw/clawhub) | Skill and plugin registry for OpenClaw | `npm install -g` |
 | [PyYAML](https://pyyaml.org/) | YAML parser for `.skill` packaging | `pip install` |
 | libvips | Image processing headers for sharp build | `pkg install` (on update) |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -166,6 +166,18 @@ openclaw gateway
 
 > 要停止网关，按 `Ctrl+C`。不要使用 `Ctrl+Z` — 它只会挂起进程而不会终止它。
 
+## 安装 OpenClaw 插件
+
+`openclaw gateway` 运行后，可以打开第二个 Termux 标签页安装可选的 OpenClaw 插件。例如，[TweetClaw](https://github.com/Xquik-dev/tweetclaw) 为 X/Twitter 自动化提供 search tweets、search tweet replies、follower export、user lookup、media upload and download、direct messages、monitors、webhooks、giveaway draws，以及经过审核的 post 或 reply 工作流。
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
+```bash
+openclaw plugins install clawhub:@xquik/tweetclaw
+```
+
+TweetClaw 可以在未配置凭据时安装。安装后，通过 OpenClaw 插件配置添加 Xquik 访问权限。保持网关标签页运行，并在单独的标签页完成插件设置。
+
 ## 保持进程存活
 
 Android 可能会在屏幕关闭时杀死后台进程或对其进行限制。详细的推荐设置请参阅 [保持进程存活指南](docs/disable-phantom-process-killer.md)（开发者选项、保持唤醒、充电限制、电池优化和 Phantom Process Killer）。
@@ -294,7 +306,7 @@ OpenClaw 通过 [node-llama-cpp](https://github.com/withcatai/node-llama-cpp) �
 | 组件 | 作用 | 安装方式 |
 |-----------|------|----------------|
 | [OpenClaw](https://github.com/openclaw/openclaw) | AI Agent 平台（核心） | `npm install -g` |
-| [clawdhub](https://github.com/AidanPark/clawdhub) | OpenClaw 的技能管理器 | `npm install -g` |
+| [ClawHub](https://github.com/openclaw/clawhub) | OpenClaw 的技能和插件注册中心 | `npm install -g` |
 | [PyYAML](https://pyyaml.org/) | `.skill` 打包的 YAML 解析器 | `pip install` |
 | libvips | sharp 构建所需的图像处理头文件 | `pkg install`（更新时） |
 

--- a/docs/superpowers/plans/2026-03-31-playwright-install-option.md
+++ b/docs/superpowers/plans/2026-03-31-playwright-install-option.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Create `scripts/install-playwright.sh`
+## Task 1: Create `scripts/install-playwright.sh`
 
 **Files:**
 - Create: `scripts/install-playwright.sh`
@@ -165,7 +165,7 @@ Run: `chmod +x scripts/install-playwright.sh`
 
 ---
 
-### Task 2: Add Playwright to `install-tools.sh`
+## Task 2: Add Playwright to `install-tools.sh`
 
 **Files:**
 - Modify: `install-tools.sh:79` (tool detection)
@@ -240,7 +240,7 @@ fi
 
 ---
 
-### Task 3: Verify
+## Task 3: Verify
 
 - [ ] **Step 1: Syntax check install-playwright.sh**
 


### PR DESCRIPTION
## Summary

- add post-gateway OpenClaw plugin setup to the English, Korean, and Chinese READMEs
- use TweetClaw as a concrete optional X automation plugin example
- add the required Xquik independence and trademark notice in all 3 translations
- replace the dead AidanPark/clawdhub link with the canonical openclaw/clawhub repository
- update ClawHub descriptions to cover its current skill and plugin registry role
- repair the existing Playwright plan heading hierarchy so the repository-wide Markdown gate passes

## Independent upstream fix

The previous ClawHub repository link no longer resolves. This PR points all 3 README translations to the live canonical repository and updates its current role. It also fixes 3 invalid heading levels in the existing Playwright implementation plan, which previously failed the repository Markdown quality gate.

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli2 README.md README.ko.md README.zh.md`
- `npx --yes markdownlint-cli2 **/*.md` with the repository workflow exclusions: 15 files, 0 issues
- verified the TweetClaw and canonical ClawHub repository URLs
- `npm view @xquik/tweetclaw version openclaw.install --json`

Disclosure: I maintain Xquik and built the TweetClaw plugin.