### PR TITLE
Verify bootstrap artifacts before extraction

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,6 +33,16 @@ android {
         )
         buildConfigField(
             "String",
+            "BOOTSTRAP_VERSION",
+            "\"2026.02.12-r1+apt.android-7\"",
+        )
+        buildConfigField(
+            "String",
+            "BOOTSTRAP_SHA256",
+            "\"ea2aeba8819e517db711f8c32369e89e7c52cee73e07930ff91185e1ab93f4f3\"",
+        )
+        buildConfigField(
+            "String",
             "WWW_URL",
             "\"https://github.com/AidanPark/openclaw-android-app/releases/download/v1.0.0/www.zip\"",
         )

--- a/android/app/src/main/java/com/openclaw/android/BootstrapManager.kt
+++ b/android/app/src/main/java/com/openclaw/android/BootstrapManager.kt
@@ -3,6 +3,7 @@ package com.openclaw.android
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.Closeable
 import java.io.File
 import java.io.InputStream
 import java.net.URL
@@ -77,11 +78,13 @@ class BootstrapManager(
 
             // Step 1: Download or extract bootstrap
             onProgress(PROGRESS_PREPARING, "Preparing bootstrap...")
-            val zipStream = getBootstrapStream(onProgress)
+            val bootstrapArchive = getBootstrapArchive(onProgress)
 
             // Step 2: Extract bootstrap
             onProgress(PROGRESS_EXTRACTING, "Extracting bootstrap...")
-            extractBootstrap(zipStream)
+            bootstrapArchive.use { archive ->
+                extractBootstrap(archive.inputStream)
+            }
 
             // Step 3: Fix paths and configure
             onProgress(PROGRESS_CONFIGURING, "Configuring environment...")
@@ -100,17 +103,39 @@ class BootstrapManager(
 
     // --- Bootstrap source ---
 
-    private suspend fun getBootstrapStream(onProgress: (Float, String) -> Unit): InputStream {
+    private suspend fun getBootstrapArchive(onProgress: (Float, String) -> Unit): BootstrapArchive {
         // Phase 0: Try assets first
         try {
-            return context.assets.open("bootstrap-aarch64.zip")
+            return BootstrapArchive(context.assets.open("bootstrap-aarch64.zip"))
         } catch (_: Exception) {
             // Phase 1: Download from network
         }
 
         onProgress(PROGRESS_DOWNLOADING, "Downloading bootstrap...")
-        val url = UrlResolver(context).getBootstrapUrl()
-        return URL(url).openStream()
+        val component = UrlResolver(context).getBootstrapComponent()
+        val archive = downloadVerifiedBootstrap(component)
+        return BootstrapArchive(archive.inputStream(), archive)
+    }
+
+    private fun downloadVerifiedBootstrap(component: UrlResolver.ComponentConfig): File {
+        val version = BootstrapSecurity.requireVersion(component.version)
+        val expectedSha256 = BootstrapSecurity.requireSha256(component.sha256)
+        val archive = File(context.cacheDir, "bootstrap-aarch64.zip")
+        archive.delete()
+
+        try {
+            URL(component.url).openStream().use { input ->
+                archive.outputStream().use { output -> input.copyTo(output) }
+            }
+            val actualSha256 = BootstrapSecurity.sha256Hex(archive)
+            if (actualSha256 != expectedSha256) {
+                throw SecurityException("Bootstrap SHA-256 mismatch for version $version")
+            }
+            return archive
+        } catch (e: Exception) {
+            archive.delete()
+            throw e
+        }
     }
 
     // --- Extraction ---
@@ -136,7 +161,7 @@ class BootstrapManager(
         if (entry.name == "SYMLINKS.txt") {
             processSymlinks(zip, stagingDir)
         } else if (!entry.isDirectory) {
-            val file = File(stagingDir, entry.name)
+            val file = BootstrapSecurity.resolveInsideDirectory(stagingDir, entry.name)
             file.parentFile?.mkdirs()
             file.outputStream().use { out -> zip.copyTo(out) }
             markExecutableIfNeeded(file, entry.name)
@@ -191,7 +216,7 @@ class BootstrapManager(
             }.forEach { parts ->
                 val symlinkTarget = parts[0].trim().replace("com.termux", ourPackage)
                 val symlinkPath = parts[1].trim()
-                val linkFile = File(targetDir, symlinkPath)
+                val linkFile = BootstrapSecurity.resolveInsideDirectory(targetDir, symlinkPath)
                 linkFile.parentFile?.mkdirs()
                 try {
                     Os.symlink(symlinkTarget, linkFile.absolutePath)
@@ -453,6 +478,16 @@ exit ${d}_rc
             AppLogger.i(TAG, "oa CLI installed at ${oaBin.absolutePath}")
         } catch (e: Exception) {
             AppLogger.w(TAG, "Failed to install oa CLI", e)
+        }
+    }
+
+    private data class BootstrapArchive(
+        val inputStream: InputStream,
+        val temporaryFile: File? = null,
+    ) : Closeable {
+        override fun close() {
+            inputStream.close()
+            temporaryFile?.delete()
         }
     }
 }

--- a/android/app/src/main/java/com/openclaw/android/BootstrapSecurity.kt
+++ b/android/app/src/main/java/com/openclaw/android/BootstrapSecurity.kt
@@ -1,0 +1,66 @@
+package com.openclaw.android
+
+import java.io.File
+import java.security.MessageDigest
+import java.util.Locale
+
+internal object BootstrapSecurity {
+    private val sha256Pattern = Regex("^[A-Fa-f0-9]{64}$")
+
+    fun requireVersion(version: String?): String {
+        val normalized = version?.trim()
+        require(!normalized.isNullOrEmpty()) { "Bootstrap version is required" }
+        return normalized
+    }
+
+    fun requireSha256(sha256: String?): String {
+        val normalized = sha256?.trim()
+        require(!normalized.isNullOrEmpty()) { "Bootstrap SHA-256 is required" }
+        require(sha256Pattern.matches(normalized)) {
+            "Bootstrap SHA-256 must be a 64-character hex digest"
+        }
+        return normalized.lowercase(Locale.US)
+    }
+
+    fun sha256Hex(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().toHexString()
+    }
+
+    fun resolveInsideDirectory(
+        rootDir: File,
+        entryName: String,
+    ): File {
+        require(entryName.isNotBlank()) { "Bootstrap zip entry name is empty" }
+        val root = rootDir.canonicalFile
+        val target = File(root, entryName).canonicalFile
+        require(target.path.startsWith(root.path + File.separator)) {
+            "Unsafe bootstrap zip entry: $entryName"
+        }
+        return target
+    }
+
+    private fun ByteArray.toHexString(): String {
+        val hex = CharArray(size * HEX_CHARS_PER_BYTE)
+        forEachIndexed { index, byte ->
+            val value = byte.toInt() and BYTE_MASK
+            hex[index * HEX_CHARS_PER_BYTE] = HEX_CHARS[value ushr NIBBLE_BITS]
+            hex[index * HEX_CHARS_PER_BYTE + 1] = HEX_CHARS[value and NIBBLE_MASK]
+        }
+        return String(hex)
+    }
+
+    private const val BYTE_MASK = 0xff
+    private const val NIBBLE_MASK = 0x0f
+    private const val NIBBLE_BITS = 4
+    private const val HEX_CHARS_PER_BYTE = 2
+    private val HEX_CHARS = "0123456789abcdef".toCharArray()
+}

--- a/android/app/src/main/java/com/openclaw/android/UrlResolver.kt
+++ b/android/app/src/main/java/com/openclaw/android/UrlResolver.kt
@@ -26,10 +26,16 @@ class UrlResolver(
         )
     private val gson = Gson()
 
-    suspend fun getBootstrapUrl(): String {
+    suspend fun getBootstrapComponent(): ComponentConfig {
         val config = loadConfig()
-        return config?.bootstrap?.url ?: BuildConfig.BOOTSTRAP_URL
+        return config?.bootstrap ?: ComponentConfig(
+            url = BuildConfig.BOOTSTRAP_URL,
+            version = BuildConfig.BOOTSTRAP_VERSION,
+            sha256 = BuildConfig.BOOTSTRAP_SHA256,
+        )
     }
+
+    suspend fun getBootstrapUrl(): String = getBootstrapComponent().url
 
     suspend fun getWwwUrl(): String {
         val config = loadConfig()

--- a/android/app/src/test/java/com/openclaw/android/BootstrapSecurityTest.kt
+++ b/android/app/src/test/java/com/openclaw/android/BootstrapSecurityTest.kt
@@ -1,0 +1,76 @@
+package com.openclaw.android
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class BootstrapSecurityTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `requireSha256 normalizes valid digest`() {
+        val digest = "EA2AEBA8819E517DB711F8C32369E89E7C52CEE73E07930FF91185E1AB93F4F3"
+
+        assertEquals(
+            "ea2aeba8819e517db711f8c32369e89e7c52cee73e07930ff91185e1ab93f4f3",
+            BootstrapSecurity.requireSha256(digest),
+        )
+    }
+
+    @Test
+    fun `requireSha256 rejects missing or malformed digest`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BootstrapSecurity.requireSha256(null)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            BootstrapSecurity.requireSha256("not-a-sha256")
+        }
+    }
+
+    @Test
+    fun `sha256Hex hashes file contents`() {
+        val file = File(tempDir, "bootstrap.zip")
+        file.writeText("bootstrap")
+
+        assertEquals(
+            "333c04dd151a2a6831c039cb9a651df29198be8a04e16ce861d4b6a34a11c954",
+            BootstrapSecurity.sha256Hex(file),
+        )
+    }
+
+    @Test
+    fun `requireVersion rejects missing version`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BootstrapSecurity.requireVersion(null)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            BootstrapSecurity.requireVersion(" ")
+        }
+    }
+
+    @Test
+    fun `resolveInsideDirectory accepts nested entry`() {
+        val target = BootstrapSecurity.resolveInsideDirectory(tempDir, "bin/sh")
+
+        assertTrue(target.path.startsWith(tempDir.canonicalPath + File.separator))
+        assertEquals("sh", target.name)
+    }
+
+    @Test
+    fun `resolveInsideDirectory rejects traversal entry`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BootstrapSecurity.resolveInsideDirectory(tempDir, "../escaped-proof.txt")
+        }
+    }
+
+    @Test
+    fun `resolveInsideDirectory rejects absolute entry`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BootstrapSecurity.resolveInsideDirectory(tempDir, "/tmp/escaped-proof.txt")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add fallback bootstrap version and SHA-256 metadata for the built-in Termux bootstrap URL
- require network bootstrap downloads to provide version and SHA-256 metadata, then verify downloaded bytes before extraction
- reject unsafe bootstrap zip and SYMLINKS paths that escape the staging directory

Closes #138

## Testing
- Not run: `./gradlew :app:testDebugUnitTest` because this environment has no Java/JDK installed (`JAVA_HOME` unset and no `java` on PATH).
- Ran a local Python harness confirming hash mismatches stop before extraction and traversal entries are rejected.